### PR TITLE
feat #50 : 1차 테스트 의견 반영

### DIFF
--- a/travel-project/src/components/RegionCard.css
+++ b/travel-project/src/components/RegionCard.css
@@ -11,20 +11,20 @@
   width: 100%;
 }
 
-.overlap-group {
+.region-overlap-group {
   border-radius: 10px;
-  height: 362px;
+  height: 370px;  /* 372px에서 370px로 변경 */
   position: relative;
   width: 227px;
 }
 
-.rectangle {
+.region-rectangle {
   background-color: #ffffff;
   border: 1px solid;
   border-color: #000000;
   border-radius: 10px;
   box-shadow: 8px 8px 4px #c9f0f766;
-  height: 362px;
+  height: 370px;  /* 372px에서 370px로 변경 */
   left: 0;
   opacity: 0.5;
   position: absolute;
@@ -86,7 +86,7 @@
   border-radius: 10px;
   height: 19px;
   position: absolute;
-  top: 338px;
+  top: 344px;  /* 342px에서 344px로 변경하여 2px 아래로 이동 */
   min-width: 30px; /* 최소 너비 */
   transition: width 0.2s ease;
   /* 더 이상 max-width 제한 없음 */
@@ -98,10 +98,14 @@
   font-size: 10px;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 14.0px;
+  line-height: 19px;  /* tag-wrapper의 높이와 동일하게 설정하여 세로 중앙 정렬 */
   position: absolute;
-  top: 339px;
+  top: 344px;  /* tag-wrapper와 동일한 top 값으로 설정 */
   white-space: nowrap;
   z-index: 1; /* 텍스트가 래퍼 위에 표시되도록 */
   text-align: center; /* 중앙 정렬 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 19px; /* tag-wrapper와 동일한 높이 */
 }

--- a/travel-project/src/components/RegionCard.jsx
+++ b/travel-project/src/components/RegionCard.jsx
@@ -45,7 +45,10 @@ const RegionTag = React.forwardRef(({ text, index, startPosition }, ref) => {
       <div
         ref={tagTextRef}
         className="region-tag"
-        style={{ left: `${startPosition + 10}px` }} // 텍스트 위치 조정
+        style={{
+          left: `${startPosition}px`,  // tag-wrapper와 동일한 위치
+          width: `${tagWrapperRef.current ? tagWrapperRef.current.style.width : 'auto'}`  // wrapper와 동일한 너비
+        }}
       >
         {text}
       </div>
@@ -142,7 +145,7 @@ export const RegionCard = ({
     cursor: "pointer",
     display: "block",
     width: "227px", // overlap-group과 동일한 너비
-    height: "362px", // overlap-group과 동일한 높이
+    height: "370px", // overlap-group과 동일한 높이
     position: "relative",
   };
 
@@ -188,10 +191,10 @@ export const RegionCard = ({
   };
 
   return (
-    <div style={{ width: "227px", height: "362px", position: "relative" }}>
+    <div style={{ width: "227px", height: "370px", position: "relative" }}>
       <div onClick={onCardClick} style={cardStyle}>
-        <div className="overlap-group">
-          <div className="rectangle" />
+        <div className="region-overlap-group">
+          <div className="region-rectangle" />
 
           <div className="regioncard-img">
             <img

--- a/travel-project/src/components/TagSelector.css
+++ b/travel-project/src/components/TagSelector.css
@@ -76,6 +76,8 @@
   min-width: 608px;
   box-shadow: 0px 5px 5px rgba(142, 142, 142, 0.2);
   margin-top: 16px; /*입력창 위로*/
+  position: relative; /* 추가: blur 영향을 받지 않도록 */
+  z-index: 1000; /* 추가: modal-backdrop보다 위에 위치 */
 }
   
   .search-bar:hover {
@@ -101,6 +103,19 @@
     flex-shrink: 0; /* 아이콘이 줄어들지 않도록 고정 */
   }
   
+  /* 모달이 열렸을 때 뒷배경 blur 효과 */
+  .modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    backdrop-filter: blur(5px);
+    background-color: rgba(0, 0, 0, 0.2);
+    z-index: 999;
+    animation: fadeIn 0.2s ease;
+  }
+  
   .tag-modal {
     position: absolute;
     top: calc(100% + 5px); /* search-bar 높이 + 약간의 간격 */
@@ -109,7 +124,7 @@
     background-color: white;
     border-radius: 8px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-    z-index: 1000;
+    z-index: 1001; /* search-bar보다 위에 위치 */
     padding: 20px;
     animation: fadeIn 0.2s ease;
   }

--- a/travel-project/src/components/TagSelector.jsx
+++ b/travel-project/src/components/TagSelector.jsx
@@ -87,6 +87,9 @@ const TagSelector = ({ onSubmit }) => {
 
   return (
     <div className="tag-selector-container">
+      {/* blur 배경 추가 */}
+      {isModalOpen && <div className="modal-backdrop" />}
+      
       <div
         ref={searchRef}
         onClick={() => {


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- resolve: #50

<br>

## ✨ Description
RegionCard, TagSelector 디자인 수정

<br>

## 📸 Screenshot
RegionCard 디자인 수정
- 카드 내에서 description 과 tag 사이에 간격 더 넓게 수정
- tag 높이 center로 수정(태그가 래퍼 중앙에 오도록 수정)
TagSelector 디자인 수정
- 클릭 시 뒷 배경 블러처리


수정 전(RegionCard)
![수정전](https://github.com/user-attachments/assets/b3d344a1-6f91-4d95-a168-bc7563b2ef7e)
수정 후(RegionCard)
![수정후](https://github.com/user-attachments/assets/41589ca5-d318-473e-96ac-6367219971da)

수정 전(TagSelector)
![수정전2](https://github.com/user-attachments/assets/8cc249a1-9ec9-48b9-a459-279d14b7607c)

수정 후(TagSelector)
![수정후2](https://github.com/user-attachments/assets/e060a6dc-e6ba-4c0e-8bb8-d48af990c375)


<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
RegionCard의 경우 description과 tag 간격을 넓게 조정하면 태그 아랫부분이 부자연스러워 카드의 길이를 362px -> 370px으로 연장하였습니다.
```
