### PR TITLE
Fix/#53 : RegionCardList 1차 수정

### DIFF
--- a/travel-project/src/App.css
+++ b/travel-project/src/App.css
@@ -36,3 +36,27 @@
     transform: rotate(360deg);
   }
 }
+
+/* 1. HTML, body, root 높이 설정 */
+/* 기본 레이아웃 설정 */
+html, body, #root {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+/* 2. 앱 전체를 flex 레이아웃으로 구성 */
+.app-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 90vh; /* 전체 화면 높이 보장 */
+}
+
+/* 3. 콘텐츠가 남은 공간을 채움 */
+.container {
+  flex: 1; /* ✅ 이게 핵심! */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+

--- a/travel-project/src/category/Footer.css
+++ b/travel-project/src/category/Footer.css
@@ -1,10 +1,12 @@
-/* Footer */
+/* Footer는 일반 Block 요소 */
 .footer {
   text-align: center;
-  padding: 10px;
-  font-size: 12px; /* ✅ 폰트 크기 12px */
-  margin-top: 30px;
-  color: rgba(79, 157, 222, 0.3); /* ✅ #4F9DDE 색상 + 30% 투명도 */
+  padding: 16px;
+  font-size: 12px;
+  background-color: white;
+  color: rgba(79, 157, 222, 0.4);
+  margin: 0; /* 혹시 margin-top 남아 있으면 제거 */
+  padding-top: 5vh;
 }
 
 .footer hr {

--- a/travel-project/src/category/Navbar.css
+++ b/travel-project/src/category/Navbar.css
@@ -22,9 +22,10 @@
 
 .navbar-right {
   display: flex;
-  gap: 40px;
+  gap: 50px;
   align-items: center;
   font-family: "Noto Sans", sans-serif;
+  padding-right: 15px
 }
 
 .navbar-right a {

--- a/travel-project/src/category/Navbar.jsx
+++ b/travel-project/src/category/Navbar.jsx
@@ -10,7 +10,7 @@ function Navbar() {
   return (
     <nav className="navbar">
       <div className="navbar-left"> {/*home 링크 수정 및 로고 수정 필요*/}
-        <Link to="/home" className="navbar-logo"> 
+        <Link to="/" className="navbar-logo"> 
           <img src={logoImg} alt="Logo" className="logo" />
 
         </Link>

--- a/travel-project/src/category/Navbar.jsx
+++ b/travel-project/src/category/Navbar.jsx
@@ -1,30 +1,35 @@
-import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import './Navbar.css';
-import logoImg from '../assets/img/mainLogo4.png'; // 상대경로 기준: src/category → src/assets/img
-
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import "./Navbar.css";
+import logoImg from "../assets/img/mainLogo4.png"; // 상대경로 기준: src/category → src/assets/img
 
 function Navbar() {
   const location = useLocation();
 
   return (
     <nav className="navbar">
-      <div className="navbar-left"> {/*home 링크 수정 및 로고 수정 필요*/}
-        <Link to="/" className="navbar-logo"> 
+      <div className="navbar-left">
+        <Link
+          to="/"
+          className="navbar-logo"
+          onClick={(e) => {
+            e.preventDefault(); // React Router 기본 동작 막고
+            window.location.href = "/"; // 강제 새로고침
+          }}
+        >
           <img src={logoImg} alt="Logo" className="logo" />
-
         </Link>
       </div>
       <div className="navbar-right">
         <Link
           to="/reviews"
-          className={location.pathname.startsWith('/reviews') ? 'active' : ''}
+          className={location.pathname.startsWith("/reviews") ? "active" : ""}
         >
           리뷰
         </Link>
         <Link
           to="/mytrips"
-          className={location.pathname.startsWith('/mytrips') ? 'active' : ''}
+          className={location.pathname.startsWith("/mytrips") ? "active" : ""}
         >
           나의 여행
         </Link>

--- a/travel-project/src/components/RegionCardList.css
+++ b/travel-project/src/components/RegionCardList.css
@@ -1,8 +1,9 @@
 .card-list-wrapper {
   width: 1300px; /* 카드 5개 x 227px + gap 고려 */
   margin: 40px auto 0; /* 상단 여백 + 가운데 정렬 */
-  padding: 0 10px; /* 좌우 내부 여백 */
+  padding: 0 0; /* 좌우 내부 여백 */
   justify-content: center;
+  padding-bottom: 70px;
 }
 
 .card-list {
@@ -11,6 +12,7 @@
   justify-content: flex-start; /* 카드 왼쪽 정렬 */
   gap: 40px; /* 카드 간 간격 */
   margin-top: 0px;
+  padding-bottom: 10px;
 }
 
 .center-text {
@@ -21,7 +23,7 @@
 }
 
 .no-results-text {
-  margin-top: 40px;
+  margin-top: 20px;
   text-align: center;
   font-size: 1.2rem;
   color: #888;
@@ -29,6 +31,16 @@
   margin-left: auto;
   margin-right: auto;
   transition: all 0.3s ease;
+}
+
+/* no-results-wrapper가 화면 남은 영역을 모두 차지하도록 설정 */
+.no-results-wrapper {
+  flex: 1;
+  display: flex;
+  justify-content: center;     /* 가로 중앙 */
+  align-items: flex-end;       /* 세로 아래쪽에 가까운 위치 */
+  min-height: 250px;           /* fallback 높이 (컨텐츠 짧을 때 대비) */
+  padding-bottom: 120px;       /* Footer와 겹치지 않도록 공간 확보 */
 }
 
 

--- a/travel-project/src/components/RegionCardList.css
+++ b/travel-project/src/components/RegionCardList.css
@@ -1,15 +1,65 @@
+.card-list-wrapper {
+  width: 1300px; /* 카드 5개 x 227px + gap 고려 */
+  margin: 40px auto 0; /* 상단 여백 + 가운데 정렬 */
+  padding: 0 10px; /* 좌우 내부 여백 */
+  justify-content: center;
+}
+
 .card-list {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 20px;
-    margin-top: 30px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start; /* 카드 왼쪽 정렬 */
+  gap: 40px; /* 카드 간 간격 */
+  margin-top: 0px;
+}
+
+.center-text {
+  text-align: center;
+  margin-top: 80px;
+  font-size: 1.8rem;
+  color: #555;
+}
+
+.no-results-text {
+  margin-top: 40px;
+  text-align: center;
+  font-size: 1.2rem;
+  color: #888;
+  max-width: 80%;
+  margin-left: auto;
+  margin-right: auto;
+  transition: all 0.3s ease;
+}
+
+
+.card {
+  flex: 1 1 calc(20% - 40px); /* 5개씩 보이게 */
+  max-width: 220px;
+  min-width: 160px;
+}
+
+/*반응형 화면*/
+@media (max-width: 1100px) {
+  .card {
+    flex: 1 1 calc(25% - 40px); /* 4개 */
   }
-  
-  .center-text {
-    text-align: center;
-    margin-top: 80px;
-    font-size: 1.8rem;
-    color: #555;
+}
+
+@media (max-width: 900px) {
+  .card {
+    flex: 1 1 calc(33.33% - 40px); /* 3개 */
   }
-  
+}
+
+@media (max-width: 700px) {
+  .card {
+    flex: 1 1 calc(50% - 40px); /* 2개 */
+  }
+}
+
+@media (max-width: 500px) {
+  .card {
+    flex: 1 1 100%; /* 1개씩 */
+  }
+}
+

--- a/travel-project/src/components/RegionCardList.jsx
+++ b/travel-project/src/components/RegionCardList.jsx
@@ -72,19 +72,27 @@ function RegionCardList() {
   return (
     <div>
       <TagSelector onSubmit={setSelectedTags} />
-      <div className="card-list">
-        {filteredCards.map((card) => (
-          <RegionCard
-            key={card.id}
-            id={card.id} // id 값 전달 추가
-            imagePath={card.image}
-            regionName={card.name}
-            regionDescription={card.description}
-            tags={card.tags}
-            url={`/detail/${card.id}`} // ✅ detail 경로도 유니크 id로 유지
-            jsonPath={card.jsonPath} // ✅ JSON 파일 경로 추가
-          />
-        ))}
+      <div className="card-list-wrapper">
+        {filteredCards.length > 0 ? (
+          <div className="card-list">
+            {filteredCards.map((card) => (
+              <RegionCard
+                key={card.id}
+                id={card.id}
+                imagePath={card.image}
+                regionName={card.name}
+                regionDescription={card.description}
+                tags={card.tags}
+                url={`/detail/${card.id}`}
+                jsonPath={card.jsonPath}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="no-results-text">
+            태그에 맞는 여행지를 찾을 수 없습니다.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/travel-project/src/components/RegionCardList.jsx
+++ b/travel-project/src/components/RegionCardList.jsx
@@ -89,10 +89,12 @@ function RegionCardList() {
             ))}
           </div>
         ) : (
+          <div className="no-results-wrapper">
           <p className="no-results-text">
             태그에 맞는 여행지를 찾을 수 없습니다.
           </p>
-        )}
+        </div>
+      )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- resolve: #53 RegionCardList 1차 수정

<br>

## ✨ Description
<!-- 작업 내용 -->
카드 사이 padding 필요
메인 카드 center 정렬이 아닌 왼쪽 정렬
Tag 선택했을 때 데이터가 없다면 등장할 안내 문구 
Tag 검색 후 로고 클릭해서 home으로 다시 돌아갈 때, tag 검색 내역이  reset
navigation Bar 오른쪽 padding 필요 
body의 기본 크기 지정해서 footer가 아래에 위치하게 수정 
<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|
![1차 수정](https://github.com/user-attachments/assets/e65cd6ab-84d5-484e-b695-e01919ca4649)

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
내용을 입력해주세요
```
